### PR TITLE
Closes #40 pretty formatter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vegas-lattice"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Oscar David Arbeláez Echeverri <odarbelaeze@gmail.com>"]
 description = "CLI and library to work with lattices"
 documentation = "https://github.com/pcm-ca/vegas-lattice-rs/wiki"

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,49 @@
+use serde_json::error::Result;
+use serde_json::ser::{Serializer, Formatter};
+use serde::ser;
+use std::io;
+
+
+pub struct LatticeFormatter {
+}
+
+
+impl Formatter for LatticeFormatter {
+}
+
+
+#[inline]
+pub fn to_writer_lattice<W, T: ?Sized>(writer: W, value: &T) -> Result<()>
+where
+    W: io::Write,
+    T: ser::Serialize,
+{
+    let mut ser = Serializer::with_formatter(writer, LatticeFormatter {});
+    try!(value.serialize(&mut ser));
+    Ok(())
+}
+
+
+#[inline]
+pub fn to_vec_lattice<T: ?Sized>(value: &T) -> Result<Vec<u8>>
+where
+    T: ser::Serialize,
+{
+    let mut writer = Vec::with_capacity(128);
+    try!(to_writer_lattice(&mut writer, value));
+    Ok(writer)
+}
+
+
+#[inline]
+pub fn to_string_lattice<T: ?Sized>(value: &T) -> Result<String>
+where
+    T: ser::Serialize,
+{
+    let vec = try!(to_vec_lattice(value));
+    let string = unsafe {
+        // We do not emit invalid UTF-8.
+        String::from_utf8_unchecked(vec)
+    };
+    Ok(string)
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -33,22 +33,21 @@ impl LatticeFormatter {
 
     #[inline]
     fn begin_colletion_item<W: ?Sized>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
-    where
-        W: io::Write,
+        where W: io::Write
     {
         match (first, self.above_max_indent()) {
             (true, false) => {
                 try!(writer.write_all(b"\n"));
                 indent(writer, self.current_indent, self.indent)
-            },
+            }
             (false, false) => {
                 try!(writer.write_all(b",\n"));
                 indent(writer, self.current_indent, self.indent)
-            },
+            }
             (false, true) => {
                 try!(writer.write_all(b", "));
                 Ok(())
-            },
+            }
             (true, true) => Ok(()),
         }
     }
@@ -62,11 +61,9 @@ impl Default for LatticeFormatter {
 
 
 impl Formatter for LatticeFormatter {
-
     #[inline]
     fn begin_array<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
-    where
-        W: io::Write,
+        where W: io::Write
     {
         self.current_indent += 1;
         self.has_value = false;
@@ -75,32 +72,26 @@ impl Formatter for LatticeFormatter {
 
     #[inline]
     fn end_array<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
-    where
-        W: io::Write,
+        where W: io::Write
     {
-
-        self.current_indent -= 1;
-
         if !self.above_max_indent() && self.has_value {
             try!(writer.write_all(b"\n"));
-            try!(indent(writer, self.current_indent, self.indent));
+            try!(indent(writer, self.current_indent - 1, self.indent));
         }
-
+        self.current_indent -= 1;
         writer.write_all(b"]")
     }
 
     #[inline]
     fn begin_array_value<W: ?Sized>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
-    where
-        W: io::Write,
+        where W: io::Write
     {
         self.begin_colletion_item(writer, first)
     }
 
     #[inline]
     fn end_array_value<W: ?Sized>(&mut self, _writer: &mut W) -> io::Result<()>
-    where
-        W: io::Write,
+        where W: io::Write
     {
         self.has_value = true;
         Ok(())
@@ -108,8 +99,7 @@ impl Formatter for LatticeFormatter {
 
     #[inline]
     fn begin_object<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
-    where
-        W: io::Write,
+        where W: io::Write
     {
         self.current_indent += 1;
         self.has_value = false;
@@ -118,8 +108,7 @@ impl Formatter for LatticeFormatter {
 
     #[inline]
     fn end_object<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
-    where
-        W: io::Write,
+        where W: io::Write
     {
         if !self.above_max_indent() && self.has_value {
             try!(writer.write_all(b"\n"));
@@ -131,24 +120,21 @@ impl Formatter for LatticeFormatter {
 
     #[inline]
     fn begin_object_key<W: ?Sized>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
-    where
-        W: io::Write,
+        where W: io::Write
     {
         self.begin_colletion_item(writer, first)
     }
 
     #[inline]
     fn begin_object_value<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
-    where
-        W: io::Write,
+        where W: io::Write
     {
         writer.write_all(b": ")
     }
 
     #[inline]
     fn end_object_value<W: ?Sized>(&mut self, _writer: &mut W) -> io::Result<()>
-    where
-        W: io::Write,
+        where W: io::Write
     {
         self.has_value = true;
         Ok(())
@@ -158,9 +144,8 @@ impl Formatter for LatticeFormatter {
 
 #[inline]
 pub fn to_writer_lattice<W, T: ?Sized>(writer: W, value: &T) -> Result<()>
-where
-    W: io::Write,
-    T: ser::Serialize,
+    where W: io::Write,
+          T: ser::Serialize
 {
     let mut ser = Serializer::with_formatter(writer, LatticeFormatter::new());
     try!(value.serialize(&mut ser));
@@ -170,8 +155,7 @@ where
 
 #[inline]
 pub fn to_vec_lattice<T: ?Sized>(value: &T) -> Result<Vec<u8>>
-where
-    T: ser::Serialize,
+    where T: ser::Serialize
 {
     let mut writer = Vec::with_capacity(128);
     try!(to_writer_lattice(&mut writer, value));
@@ -181,8 +165,7 @@ where
 
 #[inline]
 pub fn to_string_lattice<T: ?Sized>(value: &T) -> Result<String>
-where
-    T: ser::Serialize,
+    where T: ser::Serialize
 {
     let vec = try!(to_vec_lattice(value));
     let string = unsafe {
@@ -194,8 +177,7 @@ where
 
 
 fn indent<W: ?Sized>(wr: &mut W, n: usize, s: &[u8]) -> io::Result<()>
-where
-    W: io::Write,
+    where W: io::Write
 {
     for _ in 0..n {
         try!(wr.write_all(s));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,13 @@
 extern crate itertools;
 extern crate rand;
+extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
 
 pub mod error;
+pub mod io;
+
 mod site;
 mod util;
 mod vertex;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::io::{stdin, Read};
 use std::path::Path;
 
 use docopt::{ArgvMap, Docopt};
-use vegas_lattice::{Axis, Lattice, Mask, Alloy};
+use vegas_lattice::{io, Axis, Lattice, Mask, Alloy};
 
 
 const USAGE: &'static str = "
@@ -16,7 +16,7 @@ Vegas lattice.
 
 Usage:
     vegas-lattice check [<input>]
-    vegas-lattice compress [<input>]
+    vegas-lattice pretty [<input>]
     vegas-lattice drop [-x -y -z] [<input>]
     vegas-lattice expand [--x=<x> --y=<y> --z=<z>] [<input>]
     vegas-lattice alloy <source> (<target> <ratio>)... [<input>]
@@ -45,13 +45,13 @@ fn read(input: &str) -> Result<Lattice, Box<Error>> {
 }
 
 
-fn write_compressed(lattice: Lattice) {
+fn write(lattice: Lattice) {
     println!("{}", serde_json::to_string(&lattice).unwrap());
 }
 
 
-fn write(lattice: Lattice) {
-    println!("{}", serde_json::to_string_pretty(&lattice).unwrap());
+fn write_pretty(lattice: Lattice) {
+    println!("{}", io::to_string_lattice(&lattice).unwrap());
 }
 
 
@@ -80,9 +80,9 @@ fn check(args: ArgvMap) -> Result<(), Box<Error>> {
 }
 
 
-fn compress(args: ArgvMap) -> Result<(), Box<Error>> {
+fn pretty(args: ArgvMap) -> Result<(), Box<Error>> {
     let lattice = read(args.get_str("<input>"))?;
-    write_compressed(lattice);
+    write_pretty(lattice);
     Ok(())
 }
 
@@ -165,8 +165,8 @@ fn main() {
 
     if args.get_bool("check") {
         check_error(check(args));
-    } else if args.get_bool("compress") {
-        check_error(compress(args));
+    } else if args.get_bool("pretty") {
+        check_error(pretty(args));
     } else if args.get_bool("drop") {
         check_error(drop(args));
     } else if args.get_bool("alloy") {


### PR DESCRIPTION
Add a pretty formatter.

Now you can go like:

```
▶ vl check docs/bcc.json | vl pretty
{
  "size": [
    1.0,
    1.0,
    1.0
  ],
  "sites": [
    {"kind": "Fe", "position": [0.0, 0.0, 0.0], "tags": null},
    {"kind": "Pt", "position": [0.5, 0.5, 0.5], "tags": null}
  ],
  "vertices": [
    {"source": 0, "target": 1, "delta": [0, 0, 0], "tags": null},
    {"source": 0, "target": 1, "delta": [0, -1, 0], "tags": null},
    {"source": 0, "target": 1, "delta": [-1, 0, 0], "tags": null},
    {"source": 0, "target": 1, "delta": [-1, -1, 0], "tags": null}
  ]
}
```